### PR TITLE
Add getOrThrow() helper to Option and Result

### DIFF
--- a/docs/docs/option.md
+++ b/docs/docs/option.md
@@ -173,6 +173,22 @@ if (option.isSome()) {
 }
 ```
 
+### .getOrThrow()
+
+```ts
+Option<A>.getOrThrow(): A | never
+```
+
+Returns the value contained in `Some(value)`, otherwise will throw an error.
+
+```ts title="Examples"
+const value = Option.Some(1).getOrThrow();
+// 2
+
+const value = Option.None().getOrThrow();
+// Uncaught: Tried to unwrap a Option.None value
+```
+
 ### .isSome()
 
 ```ts

--- a/docs/docs/result.md
+++ b/docs/docs/result.md
@@ -168,6 +168,22 @@ Result.Error(2).getOr(1);
 // 1
 ```
 
+### .getOrThrow()
+
+```ts
+Result<A, E>.getOrThrow(): A | never
+```
+
+If the result is `Ok(value)` returns `value`, otherwise will throw an error.
+
+```ts title="Examples"
+const value = Result.Ok(1).getOrThrow();
+// 2
+
+const value = Result.Error(2).getOrThrow();
+// Uncaught: Tried to unwrap a Result.Error value
+```
+
 ### .mapOr(defaultValue, mapper)
 
 ```ts

--- a/src/AsyncData.ts
+++ b/src/AsyncData.ts
@@ -258,6 +258,16 @@ class __AsyncData<A> {
   }
 
   /**
+   * Return the loaded value if present, otherwise throw an error
+   */
+  getOrThrow(this: AsyncData<A>): A | never {
+    if (this === NOT_ASKED || this === LOADING) {
+      throw new Error("Tried to unwrap an incomplete AsyncData");
+    }
+    return (this as Done<A>).value;
+  }
+
+  /**
    * Maps the value if present, returns the fallback otherwise
    *
    * (AsyncData\<A>, B, A => B) => B

--- a/src/OptionResult.ts
+++ b/src/OptionResult.ts
@@ -605,6 +605,10 @@ class __Result<A, E> {
    */
   getOrThrow(this: Result<A, E>): A | never {
     if (this.tag === "Error") {
+      if (typeof this.error === "string") {
+        throw new Error(this.error);
+      }
+
       throw new Error("Tried to unwrap a Result.Error value");
     }
 

--- a/src/OptionResult.ts
+++ b/src/OptionResult.ts
@@ -211,6 +211,17 @@ class __Option<A> {
   }
 
   /**
+   * Return the value if present, otherwise throw an error
+   */
+  getOrThrow(this: Option<A>): A | never {
+    if (this === NONE) {
+      throw new Error("Tried to unwrap a Option.None value");
+    }
+
+    return (this as Some<A>).value;
+  }
+
+  /**
    * Return the value if present, and the fallback otherwise
    *
    * (Option\<A>, Option\<A>) => Option\<A>
@@ -587,6 +598,17 @@ class __Result<A, E> {
    */
   getOr(this: Result<A, E>, defaultValue: A): A {
     return this.tag === "Ok" ? this.value : defaultValue;
+  }
+
+  /**
+   * Return the value if present, otherwise throw an error
+   */
+  getOrThrow(this: Result<A, E>): A | never {
+    if (this.tag === "Error") {
+      throw new Error("Tried to unwrap a Result.Error value");
+    }
+
+    return this.value;
   }
 
   /**

--- a/test/AsyncData.test.ts
+++ b/test/AsyncData.test.ts
@@ -57,6 +57,16 @@ test("AsyncData.getOr", () => {
   expect(AsyncData.Done(5).getOr(0)).toEqual(5);
 });
 
+test("AsyncData.getOrThrow", () => {
+  expect(AsyncData.Done(5).getOrThrow()).toEqual(5);
+  expect(() => AsyncData.Loading<number>().getOrThrow()).toThrowError(
+    "Tried to unwrap an incomplete AsyncData",
+  );
+  expect(() => AsyncData.NotAsked<number>().getOrThrow()).toThrowError(
+    "Tried to unwrap an incomplete AsyncData",
+  );
+});
+
 test("AsyncData.mapOk", () => {
   expect(AsyncData.NotAsked<number>().mapOr(0, (x) => x * 2)).toEqual(0);
   expect(AsyncData.Loading<number>().mapOr(0, (x) => x * 2)).toEqual(0);

--- a/test/Option.test.ts
+++ b/test/Option.test.ts
@@ -42,6 +42,13 @@ test("Option.getOr", () => {
   expect(Option.None<number>().getOr(0)).toEqual(0);
 });
 
+test("Option.getOrThrow", () => {
+  expect(Option.Some(1).getOrThrow()).toEqual(1);
+  expect(() => Option.None().getOrThrow()).toThrowError(
+    "Tried to unwrap a Option.None value",
+  );
+});
+
 test("Option.mapOr", () => {
   expect(Option.Some(1).mapOr(0, (x) => x * 2)).toEqual(2);
   expect(Option.None<number>().mapOr(0, (x) => x * 2)).toEqual(0);

--- a/test/Result.test.ts
+++ b/test/Result.test.ts
@@ -76,6 +76,9 @@ test("Result.getOrThrow", () => {
   expect(() => Result.Error(1).getOrThrow()).toThrowError(
     "Tried to unwrap a Result.Error value",
   );
+  expect(() => Result.Error("AnErrorMessage").getOrThrow()).toThrowError(
+    "AnErrorMessage",
+  );
 });
 
 test("Result.mapOr", () => {

--- a/test/Result.test.ts
+++ b/test/Result.test.ts
@@ -71,6 +71,13 @@ test("Result.getOr", () => {
   expect(Result.Error<number, number>(1).getOr(0)).toEqual(0);
 });
 
+test("Result.getOrThrow", () => {
+  expect(Result.Ok(1).getOrThrow()).toEqual(1);
+  expect(() => Result.Error(1).getOrThrow()).toThrowError(
+    "Tried to unwrap a Result.Error value",
+  );
+});
+
 test("Result.mapOr", () => {
   expect(Result.Ok(1).mapOr(0, (x) => x * 2)).toEqual(2);
   expect(Result.Error<number, number>(1).mapOr(0, (x) => x * 2)).toEqual(0);


### PR DESCRIPTION
Hi!

Some of my tests needs to prepare some context by calling methods returning `Result`s. These methods are already well-tested, I do not want to bother to check again for `Ok` or `Error`. Having these shortcut helpers would help me simplify the tests.

Pretty similar to Rust's `unwrap()` methods.